### PR TITLE
Change Item::icon from a reference to a pointer

### DIFF
--- a/Tweak.xm
+++ b/Tweak.xm
@@ -51,7 +51,7 @@ typedef struct {
 	int creativeCategory;
 	float idk5;
 	float idk6;
-	uintptr_t& icon;
+	uintptr_t* icon;
 	char filler[44];
 } Item;
 


### PR DESCRIPTION
Item's default constructor is deleted because the class contains a reference, so we fix that.